### PR TITLE
Fix table extraction bug

### DIFF
--- a/src/utils/scraper-utils.js
+++ b/src/utils/scraper-utils.js
@@ -83,7 +83,11 @@ window.ScraperUtils = {
         });
         
         // Get data rows
-        const dataRows = table.querySelector('thead') ? rows.slice(0) : rows.slice(1);
+        // Prefer rows inside <tbody> if available, otherwise skip the header row
+        let dataRows = Array.from(table.querySelectorAll('tbody tr'));
+        if (dataRows.length === 0) {
+            dataRows = rows.slice(1);
+        }
         
         return dataRows.map(row => {
             const cells = row.querySelectorAll('td, th');


### PR DESCRIPTION
## Summary
- fix data row selection for tables with `<thead>` sections
- add fallback to skip header when `<tbody>` doesn't exist

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68545dae53e88333a17ed24af82c8e26